### PR TITLE
Added styling to the Cards in main.css

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
           <img src="https://www.stanley1913.com/cdn/shop/files/B2B_Web_PNG-The-Quencher-H2-O-FlowState-Tumbler-30OZ-Heather-Front.png?v=1704227518&width=1800" class="card-img-top" alt="...">
           <div class="card-body">
             <header>
-              <h2 class="card-title">THE CLEAN SLATE QUENCHER H2.0 | Heather</h2>
+              <h2 class="card-title">THE CLEAN SLATE QUENCHER H2.0 Heather</h2>
             </header>
             <p class="card-text">Start fresh in the new year. In pastels that pop, the Quencher H2.0 FlowState Tumbler is here to keep you hydrated. From picnics to carpooling, or nestled next to your yoga mat, double-wall vacuum insulation chills ice water all day long, and the slim base fits right in your cupholder.</p>
             <p class="availability">Available</p>
@@ -28,7 +28,7 @@
             </ul>
             <footer>The product specifcations are only invalid if product falls off a ceiling.</footer>
           </div>
-          <div class="card-body">
+          <div>
             <header><h4>Pricing</h4></header>
             <p>1 cup: $45.00</p>
             <p>2 cups: $85.00</p>
@@ -41,7 +41,7 @@
           <img src="https://www.stanley1913.com/cdn/shop/files/B2B_Web_PNG-The-Quencher-H2-O-FlowState-Tumbler-30OZ-Bloom-Front.png?v=1704227542&width=540" class="card-img-top" alt="...">
           <div class="card-body">
             <header>
-              <h2 class="card-title">THE CLEAN SLATE QUENCHER H2.0 | Bloom</h2>
+              <h2 class="card-title">THE CLEAN SLATE QUENCHER H2.0 Bloom</h2>
             </header>
             <p class="card-text">Start fresh in the new year. In pastels that pop, the Quencher H2.0 FlowState Tumbler is here to keep you hydrated. From picnics to carpooling, or nestled next to your yoga mat, double-wall vacuum insulation chills ice water all day long, and the slim base fits right in your cupholder.</p>
             <p class="availability">Available</p>
@@ -54,7 +54,7 @@
             </ul>
             <footer>The product specifcations are only invalid if product falls off a ceiling.</footer>
           </div>
-          <div class="card-body">
+          <div>
             <header><h4>Pricing</h4></header>
             <p>1 cup: $45.00</p>
             <p>2 cups: $85.00</p>
@@ -67,7 +67,7 @@
           <img src="https://www.stanley1913.com/cdn/shop/files/B2B_Web_PNG-The-Quencher-H2-O-FlowState-Tumbler-30OZ-Mint-Front.png?v=1704227560&width=1800" class="card-img-top" alt="...">
           <div class="card-body">
             <header>
-              <h2 class="card-title">THE CLEAN SLATE QUENCHER H2.0 | Mint</h2>
+              <h2 class="card-title">THE CLEAN SLATE QUENCHER H2.0 Mint</h2>
             </header>
             <p class="card-text">Start fresh in the new year. In pastels that pop, the Quencher H2.0 FlowState Tumbler is here to keep you hydrated. From picnics to carpooling, or nestled next to your yoga mat, double-wall vacuum insulation chills ice water all day long, and the slim base fits right in your cupholder.</p>
             <p class="availability">Not Available</p>
@@ -80,7 +80,7 @@
             </ul>
             <footer>The product specifcations are only invalid if product falls off a ceiling.</footer>
           </div>
-          <div class="card-body">
+          <div>
             <header><h4>Pricing</h4></header>
             <p>1 cup: $45.00</p>
             <p>2 cups: $85.00</p>

--- a/main.css
+++ b/main.css
@@ -1,3 +1,33 @@
-body {
-  background-color: aquamarine;
+.card-title {
+  padding-bottom: 10px;
+  border-bottom: lightblue solid 1px;
+  text-align: center;
+}
+
+img {
+  display: flex;
+  justify-content: center;
+}
+
+.card-text {
+  text-align: justify;
+  padding: 16px;
+}
+
+h4 {
+  font-weight: bold;
+}
+
+footer {
+  padding-bottom: 20px;
+}
+
+.availability {
+  width: 100%;
+  background: darkgrey;
+  color: yellow;
+}
+
+.card-body {
+  padding: 0px;
 }


### PR DESCRIPTION
1. The card title has a solid 1px border that is `lightblue`.
2. The title and product image are centered.
3. Notice that the text for the description in the image is justified.
4. The text for the product specification details and pricing details is bold.
5. The availability element extends the full width of the card, with a dark grey background and yellow text.